### PR TITLE
Add a python daos_client script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tmpfile
+
+# Redis database file
+*.rdb

--- a/daos_install.rst
+++ b/daos_install.rst
@@ -1,0 +1,27 @@
+Install DAOS from scratch
+=========================
+
+Use the guide from Github: https://github.com/daos-stack/daos/blob/master/docs/QSG/build_from_scratch.md.
+
+This process is test and run successfully on `daosfs05`.
+After installation, check `<daos_path>/install`:
+
+::
+
+    (venv) [xmei@daosfs05 daos]$ ls install/bin/
+    acl_dump_test          daos_server_helper         nvme_control_ctests
+    agent_tests            daos_storage_estimator.py  obj_ctl
+    bio_ut                 daos_test                  pl_bench
+    cart_ctl               dfs_test                   pool_scrubbing_tests
+    common_test            dfuse                      rdbt
+    crt_launch             dfuse_test                 ring_pl_map
+    daos                   dmg                        rpc_tests
+    daos_agent             drpc_engine_test           security_test
+    daos_debug_set_params  drpc_test                  self_test
+    daos_engine            eq_tests                   smd_ut
+    daos_gen_io_conf       evt_ctl                    srv_checksum_tests
+    daos_metrics           fault_status               vea_stress
+    daos_perf              hello_drpc                 vea_ut
+    daos_racer             jobtest                    vos_perf
+    daos_run_io_conf       job_tests                  vos_tests
+    daos_server            jump_pl_map

--- a/demo_daos_client.py
+++ b/demo_daos_client.py
@@ -1,0 +1,38 @@
+"""
+A demo to operate the DAOS pools/containers with Python APIs.
+
+Author: xmei@jlab.org. Created at Mar/7/2024.
+"""
+
+# DAOS official instructions and examples:
+#    - https://docs.daos.io/v2.4/user/python/
+#    - https://github.com/daos-stack/daos/tree/release/2.4/src/client/pydaos/raw
+#    - https://github.com/daos-stack/daos/blob/release/2.4/src/client/pydaos/raw/daos_api.py
+
+# Make sure the pool "python-pool" exists.
+# $ dmg system list-pools
+# Pool        Size   State Used Imbalance Disabled
+# ----        ----   ----- ---- --------- --------
+# python-pool 3.9 TB Ready 0%   0%        0/96
+
+# Create the container "py-testcont" in the above pool.
+# $ daos cont create $pool_name $cont_name -t PYTHON
+# Successfully created container 01571915-f3bc-472e-ac42-c63f02ed54fd
+#   Container UUID : 01571915-f3bc-472e-ac42-c63f02ed54fd
+#   Container Label: py-testcont
+#   Container Type : PYTHON
+
+# NOTE: UPDATE YOUR PATH HERE!!!
+# Manually import the DAOS python module
+# Find the pydaos module by: sudo find / -name "*pydaos*"
+# Usually it is at /usr/lib64/python3.6/site-packages/pydaos
+import sys
+sys.path.append('/usr/lib64/python3.6/site-packages')  # depend on your path
+from pydaos import pydaos_core
+
+POOL_NAME="python-pool"
+CONT_LABEL="py-testcont"
+
+# Ref: https://github.com/daos-stack/daos/blob/release/2.4/src/client/pydaos/pydaos_core.py
+dcont = pydaos_core.DCont(pool=POOL_NAME, cont=CONT_LABEL)
+print(dcont)

--- a/demo_writer.py
+++ b/demo_writer.py
@@ -1,6 +1,10 @@
+"""
+Read from a 10 MB base64 file by every 9 KB and write to a redis stream "ejfat".
+"""
+
 import redis
 
-def write_file_to_redis_stream(file_path, stream_name, chunk_size=8192):
+def write_file_to_redis_stream(file_path, stream_name, chunk_size=9000):
     """
     Args:
       - chunk_size: chunck size in bytes.
@@ -31,7 +35,8 @@ def write_file_to_redis_stream(file_path, stream_name, chunk_size=8192):
             entry_id += 1
 
 if __name__ == "__main__":
-    file_path = 'test_file'
+    file_path = 'tmpfile'
+    # Generate a 10 MB base64 testfile with: openssl rand -base64 -out tmpfile 10000000
     stream_name = 'ejfat'
 
     write_file_to_redis_stream(file_path, stream_name)


### PR DESCRIPTION
Test passed on `daosfs01`.
The key is to locate the pydaos module and append it to path.

Test:
```
[xmei@daosfs01 ~/redis_demo]$ conda activate daos_test

(daos_test) [xmei@daosfs01 ~/redis_demo]$ python3 demo_daos_client.py
python-pool/py-testcont
```